### PR TITLE
testnet rollback to version xinfinorg/xdposchain:v1.4.8-beta

### DIFF
--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xinfinnetwork:
-    image: xinfinorg/xdposchain:v1.4.9-beta-2
+    image: xinfinorg/xdposchain:v1.4.8-beta
     volumes:
       - "./xdcchain-testnet:/work/xdcchain"
       - "./start-apothem.sh:/work/start.sh"


### PR DESCRIPTION
Due to testnet issue, we rollback to v1.4.8-beta