### PR TITLE
support docker compose

### DIFF
--- a/devnet/docker-down.sh
+++ b/devnet/docker-down.sh
@@ -1,1 +1,10 @@
-HOSTIP=$(curl https://checkip.amazonaws.com)  docker-compose -f docker-compose.yml down
+#!/bin/bash
+
+which docker-compose
+
+if [[ $? != 0 ]]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
+HOSTIP=$(curl https://checkip.amazonaws.com) docker-compose -f docker-compose.yml down

--- a/devnet/docker-up.sh
+++ b/devnet/docker-up.sh
@@ -1,1 +1,10 @@
-HOSTIP=$(curl https://checkip.amazonaws.com)  docker-compose -f docker-compose.yml up -d
+#!/bin/bash
+
+which docker-compose
+
+if [[ $? != 0 ]]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
+HOSTIP=$(curl https://checkip.amazonaws.com) docker-compose -f docker-compose.yml up -d

--- a/mainnet/docker-down.sh
+++ b/mainnet/docker-down.sh
@@ -1,1 +1,10 @@
-sudo docker-compose -f docker-compose.yml down
+#!/bin/bash
+
+which docker-compose
+
+if [[ $? != 0 ]]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
+docker-compose -f docker-compose.yml down

--- a/mainnet/docker-up.sh
+++ b/mainnet/docker-up.sh
@@ -1,1 +1,10 @@
-sudo docker-compose -f docker-compose.yml up -d
+#!/bin/bash
+
+which docker-compose
+
+if [[ $? != 0 ]]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
+docker-compose -f docker-compose.yml up -d

--- a/testnet/docker-down.sh
+++ b/testnet/docker-down.sh
@@ -1,1 +1,10 @@
-sudo docker-compose -f docker-compose.yml down
+#!/bin/bash
+
+which docker-compose
+
+if [[ $? != 0 ]]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
+docker-compose -f docker-compose.yml down

--- a/testnet/docker-up.sh
+++ b/testnet/docker-up.sh
@@ -1,1 +1,10 @@
+#!/bin/bash
+
+which docker-compose
+
+if [[ $? != 0 ]]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
 docker-compose -f docker-compose.yml up -d --build --force-recreate


### PR DESCRIPTION
# About this PR

## 1. Support `docker compose`

Set docker-compose as an alias of `docker compose` when docker-compose is not found.

## 2. Remove `sudo` in scripts

If the user has docker permission:

```bash
./docker-up.sh
./docker-down.sh
```

If the user has no docker permission:

```bash
sudo ./docker-up.sh
sudo ./docker-down.sh
```

BTW: how to grant docker permission:

```bash
sudo adduser ${USER} docker 
newgrp docker
```

