### PR TITLE
use flag --apothem to start tesetnet

### DIFF
--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -38,6 +38,7 @@ XDC --ethstats ${netstats} --gcmode=archive \
     --bootnodes ${bootnodes} --syncmode ${NODE_TYPE} \
     --datadir /work/xdcchain \
     --networkid 51 -port 30304 \
+    --apothem \
     --rpc --rpccorsdomain "*" --rpcaddr 0.0.0.0 \
     --rpcport 8555 \
     --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd \


### PR DESCRIPTION
We can use flag `--apothem` to start testnet. So we can remove the first line `fullVerify = false` in the function `verifyHeader`, while mainet requires `fullVerify` to be true. Then we can keep same codes between mainnet and testnet.

```go
func (x *XDPoS_v1) verifyHeader(chain consensus.ChainReader, header *types.Header, parents []*types.Header, fullVerify bool) error {
	fullVerify = false
	// If we're running a engine faking, accept any block as valid
	if x.config.SkipV1Validation {
		return nil
	}
	if common.IsTestnet {
		fullVerify = false
	}
```