### PR TITLE
Revert "use flag --apothem to start tesetnet" for now

### DIFF
--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -38,7 +38,6 @@ XDC --ethstats ${netstats} --gcmode=archive \
     --bootnodes ${bootnodes} --syncmode ${NODE_TYPE} \
     --datadir /work/xdcchain \
     --networkid 51 -port 30304 \
-    --apothem \
     --rpc --rpccorsdomain "*" --rpcaddr 0.0.0.0 \
     --rpcport 8555 \
     --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd \


### PR DESCRIPTION
Reverts XinFinOrg/XinFin-Node#137 for now
After this PR https://github.com/XinFinOrg/XDPoSChain/pull/603 merge into master, then we can revert it back.