### PR TITLE
fix wrong datadir for XDCx

### DIFF
--- a/devnet/start.sh
+++ b/devnet/start.sh
@@ -32,6 +32,7 @@ XDC \
 --syncmode ${NODE_TYPE} \
 --datadir /work/xdcchain \
 --networkid 551 \
+--XDCx.datadir /work/xdcchain/XDCx \
 --port 30303 \
 --rpc \
 --rpccorsdomain "*" \

--- a/devnet/start.sh
+++ b/devnet/start.sh
@@ -25,13 +25,29 @@ netstats="${wallet}_${INSTANCE_IP}:xinfin_xdpos_hybrid_network_stats@devnetstats
 
 echo "Starting nodes with $bootnodes ..."
 
-XDC --ethstats ${netstats} --gcmode=archive \
---bootnodes ${bootnodes} --syncmode ${NODE_TYPE} \
---datadir /work/xdcchain --networkid 551 \
--port 30303 --rpc --rpccorsdomain "*" --rpcaddr 0.0.0.0 \
+XDC \
+--ethstats ${netstats} \
+--gcmode=archive \
+--bootnodes ${bootnodes} \
+--syncmode ${NODE_TYPE} \
+--datadir /work/xdcchain \
+--networkid 551 \
+--port 30303 \
+--rpc \
+--rpccorsdomain "*" \
+--rpcaddr 0.0.0.0 \
 --rpcport 8545 \
 --rpcapi db,eth,debug,miner,net,shh,txpool,personal,web3,XDPoS \
---rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd --mine \
---gasprice "1" --targetgaslimit "420000000" --verbosity 3 \
---ws --wsaddr=0.0.0.0 --wsport 8555 \
---wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
+--rpcvhosts "*" \
+--unlock "${wallet}" \
+--password /work/.pwd \
+--mine \
+--gasprice "1" \
+--targetgaslimit "420000000" \
+--verbosity 3 \
+--ws \
+--wsaddr=0.0.0.0 \
+--wsport 8555 \
+--wsorigins "*" \
+2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
+

--- a/mainnet/start-node.sh
+++ b/mainnet/start-node.sh
@@ -36,6 +36,7 @@ XDC \
 --bootnodes ${bootnodes} \
 --syncmode ${NODE_TYPE} \
 --datadir /work/xdcchain \
+--XDCx.datadir /work/xdcchain/XDCx \
 --networkid 50 \
 --port 30303 \
 --rpc \

--- a/mainnet/start-node.sh
+++ b/mainnet/start-node.sh
@@ -31,4 +31,27 @@ INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${INSTANCE_NAME}:xinfin_xdpos_hybrid_network_stats@stats.xinfin.network:3000"
 
 echo "Starting nodes with $bootnodes ..."
-XDC --ethstats ${netstats} --bootnodes ${bootnodes} --syncmode ${NODE_TYPE} --datadir /work/xdcchain --networkid 50 -port 30303 --rpc --rpccorsdomain "*" --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts "*"  --ws --wsaddr="0.0.0.0" --wsorigins "*" --wsport 8546 --unlock "${wallet}" --password /work/.pwd --mine --gasprice "1" --targetgaslimit "420000000" --verbosity 3 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
+XDC \
+--ethstats ${netstats} \
+--bootnodes ${bootnodes} \
+--syncmode ${NODE_TYPE} \
+--datadir /work/xdcchain \
+--networkid 50 \
+--port 30303 \
+--rpc \
+--rpccorsdomain "*" \
+--rpcaddr 0.0.0.0 \
+--rpcport 8545 \
+--rpcvhosts "*" \
+--ws \
+--wsaddr="0.0.0.0" \
+--wsorigins "*" \
+--wsport 8546 \
+--unlock "${wallet}" \
+--password /work/.pwd \
+--mine \
+--gasprice "1" \
+--targetgaslimit "420000000" \
+--verbosity 3 \
+2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
+

--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -40,6 +40,7 @@ XDC \
 --bootnodes ${bootnodes} \
 --syncmode ${NODE_TYPE} \
 --datadir /work/xdcchain \
+--XDCx.datadir /work/xdcchain/XDCx \
 --networkid 51 \
 --port 30304 \
 --rpc \

--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -34,13 +34,28 @@ INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${NODE_NAME}:xdc_xinfin_apothem_network_stats@stats.apothem.network:2000"
 
 echo "Starting nodes with $bootnodes ..."
-XDC --ethstats ${netstats} --gcmode=archive \
-    --bootnodes ${bootnodes} --syncmode ${NODE_TYPE} \
-    --datadir /work/xdcchain \
-    --networkid 51 -port 30304 \
-    --rpc --rpccorsdomain "*" --rpcaddr 0.0.0.0 \
-    --rpcport 8555 \
-    --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd \
-    --mine --gasprice "1" --targetgaslimit "420000000" \
-    --verbosity 2 --ws --wsaddr=0.0.0.0 --wsport 8556 \
-    --wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
+XDC \
+--ethstats ${netstats} \
+--gcmode=archive \
+--bootnodes ${bootnodes} \
+--syncmode ${NODE_TYPE} \
+--datadir /work/xdcchain \
+--networkid 51 \
+--port 30304 \
+--rpc \
+--rpccorsdomain "*" \
+--rpcaddr 0.0.0.0 \
+--rpcport 8555 \
+--rpcvhosts "*" \
+--unlock "${wallet}" \
+--password /work/.pwd \
+--mine \
+--gasprice "1" \
+--targetgaslimit "420000000" \
+--verbosity 2 \
+--ws \
+--wsaddr=0.0.0.0 \
+--wsport 8556 \
+--wsorigins "*" \
+2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
+


### PR DESCRIPTION
This PR:

- format start scripts
- set datadir of XDCx to fix below panic:

```text
INFO [08-15|16:04:18] Maximum peer count                       ETH=25 LES=0 total=25
INFO [08-15|16:04:18] Set global gas cap                       cap=25000000
INFO [08-15|16:04:18] XDCX datadir                             path=/home/me/.XDC
INFO [08-15|16:04:18] Allocated cache and file handles         database=/home/me/.XDC cache=134.22mB handles=1024
ERROR[08-15|16:04:18] Can't create new DB                      error="resource temporarily unavailable"
INFO [08-15|16:04:18] Starting peer-to-peer node               instance=XDC/v2.3.1-beta1-e3df8e55/linux-amd64/go1.21.13
INFO [08-15|16:04:18] Allocated cache and file handles         database=/home/me/xdc_data/xinfin2/XDC/chaindata cache=805.31mB handles=32768
INFO [08-15|16:04:27] [configOrDefault] load mainnetconfig
INFO [08-15|16:04:27] Initialised chain configuration          config="{ChainID: 50 Homestead: 1 DAO: <nil> DAOSupport: false EIP150: 2 EIP155: 3 EIP158: 3 Byzantium: 4 Constantinople: <nil> Istanbul: 38383838  BerlinBlock: 76321000 LondonBlock: 76321000 MergeBlock: 76321000 Shangh
aiBlock: 76321000 Eip1559Block: 9999999999 Engine: XDPoS}"
INFO [08-15|16:04:27] [New] initialise consensus engines
INFO [08-15|16:04:27] xdc config loading                       v2 config="&{lock:{w:{state:0 sema:0} writerSem:0 readerSem:0 readerCount:{_:{} v:0} readerWait:{_:{} v:0}} SwitchBlock:+78678000 CurrentConfig:0xc00004a420 AllConfigs:map[0:0xc00004a420] configIndex:[] SkipV2Validation
:false}"
INFO [08-15|16:04:27] [BuildConfigIndex] config list           list=[0]
INFO [08-15|16:04:27] Initialising Ethereum protocol           versions="[101 100 65 64 63]" network=50
INFO [08-15|16:04:27] Loaded most recent local header          number=78478720 hash=001472…a4081a td=7228312807
INFO [08-15|16:04:27] Loaded most recent local full block      number=78478720 hash=001472…a4081a td=7228312807
INFO [08-15|16:04:27] Loaded most recent local fast block      number=78478720 hash=001472…a4081a td=7228312807
INFO [08-15|16:04:27] Loaded local transaction journal         transactions=0 dropped=0
INFO [08-15|16:04:27] Regenerated local transaction journal    transactions=0 accounts=0
INFO [08-15|16:04:27] Gasprice oracle is ignoring threshold set threshold=2
INFO [08-15|16:04:27] New local node record                    seq=1 id=46ce7861d3cec44d ip=127.0.0.1 udp=30303 tcp=30303
INFO [08-15|16:04:27] Started P2P networking                   self=enode://6a5e501ebb27badc79bc333bf0ed3aaf76790be2c134af1e870bf2ec0d5bfd4f66c3a074802e073a784d69c762d5759a460891ef7fba3e6adfa8a7c714a1cc1a@127.0.0.1:30303
INFO [08-15|16:04:27] BFT Loop Start
INFO [08-15|16:04:27] NewHTTPServer                            writeTimeout=5m0s
INFO [08-15|16:04:27] HTTP endpoint opened                     url=http://0.0.0.0:8545 cors=* vhosts=*
INFO [08-15|16:04:27] WebSocket endpoint opened                url=ws://[::]:8546
INFO [08-15|16:04:27] IPC endpoint opened                      url=/home/me/xdc_data/xinfin2/XDC.ipc
INFO [08-15|16:04:31] Block synchronisation started
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xccffae]

goroutine 285 [running]:
github.com/XinFinOrg/XDPoSChain/XDCxDAO.(*BatchDatabase).NewBatch(0x12f2d43?)
        /home/me/XDPoSChain/XDCxDAO/leveldb.go:109 +0xe
github.com/XinFinOrg/XDPoSChain/trie.(*Database).Commit(0xc0003aea90, {0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6, 0xff, ...}, ...)
        /home/me/XDPoSChain/trie/database.go:701 +0x79
github.com/XinFinOrg/XDPoSChain/core.(*BlockChain).WriteBlockWithState(0xc00e146000, 0xc000050fc0, {0xc011154230, 0x2, 0x2}, 0xc00f5fc2d0, 0xc00f78e000, 0xc00f78e080)
        /home/me/XDPoSChain/core/blockchain.go:1259 +0x16f6
github.com/XinFinOrg/XDPoSChain/core.(*BlockChain).insertChain(0xc00e146000, {0xc00e196f00, 0x2, 0x2}, 0x1)
        /home/me/XDPoSChain/core/blockchain.go:1717 +0x3b11
github.com/XinFinOrg/XDPoSChain/core.(*BlockChain).InsertChain(0xc00f5a0500?, {0xc00e196f00?, 0x4?, 0x4?})
        /home/me/XDPoSChain/core/blockchain.go:1445 +0x25
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).importBlockResults(0xc02a645a00, {0xc00e196ef0, 0x2, 0x2064b2?})
        /home/me/XDPoSChain/eth/downloader/downloader.go:1397 +0x3f8
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).processFullSyncContent(0xc02a645a00, 0x4ad7da1)
        /home/me/XDPoSChain/eth/downloader/downloader.go:1357 +0x576
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).syncWithPeer.func8()
        /home/me/XDPoSChain/eth/downloader/downloader.go:478 +0x1b
github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync.func1()
        /home/me/XDPoSChain/eth/downloader/downloader.go:491 +0x5d
created by github.com/XinFinOrg/XDPoSChain/eth/downloader.(*Downloader).spawnSync in goroutine 291
        /home/me/XDPoSChain/eth/downloader/downloader.go:491 +0x7a
```