### PR TITLE
map start-apothem.sh as work/start.sh for mainnet

### DIFF
--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - "./xdcchain:/work/xdcchain"
       - "./genesis.json:/work/genesis.json"
-      - "./start-node.sh:/work/start-node.sh"
+      - "./start-node.sh:/work/start.sh"
       - "./bootnodes.list:/work/bootnodes.list"
       - "./.pwd:/work/.pwd"
       - "/etc/localtime:/etc/localtime:ro"


### PR DESCRIPTION
Now the devnet and testnet mount start-node.sh as /work/start.sh, but the mainet do not. Thus we can't change the start script of mainnet. So this PR also mount start-node.sh as /work/start.sh for mainnet by modify mainnet/docker-compose.yml.