### PR TITLE
fix XDC init command in start scripts

### DIFF
--- a/devnet/start.sh
+++ b/devnet/start.sh
@@ -1,24 +1,21 @@
 #!/bin/bash
-if [ ! -d /work/xdcchain/XDC/chaindata ]
-then
-  echo $PRIVATE_KEY >> /tmp/key
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
-  XDC --datadir /work/xdcchain init /work/genesis.json
+if [ ! -d /work/xdcchain/XDC/chaindata ]; then
+    echo $PRIVATE_KEY >>/tmp/key
+    wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
+    XDC init --datadir /work/xdcchain /work/genesis.json
 else
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
+    wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
 fi
 
 input="/work/bootnodes.list"
 bootnodes=""
-while IFS= read -r line
-do
-    if [ -z "${bootnodes}" ]
-    then
+while IFS= read -r line; do
+    if [ -z "${bootnodes}" ]; then
         bootnodes=$line
     else
         bootnodes="${bootnodes},$line"
     fi
-done < "$input"
+done <"$input"
 
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${wallet}_${INSTANCE_IP}:xinfin_xdpos_hybrid_network_stats@devnetstats.apothem.network:2000"
@@ -26,29 +23,28 @@ netstats="${wallet}_${INSTANCE_IP}:xinfin_xdpos_hybrid_network_stats@devnetstats
 echo "Starting nodes with $bootnodes ..."
 
 XDC \
---ethstats ${netstats} \
---gcmode=archive \
---bootnodes ${bootnodes} \
---syncmode ${NODE_TYPE} \
---datadir /work/xdcchain \
---networkid 551 \
---XDCx.datadir /work/xdcchain/XDCx \
---port 30303 \
---rpc \
---rpccorsdomain "*" \
---rpcaddr 0.0.0.0 \
---rpcport 8545 \
---rpcapi db,eth,debug,miner,net,shh,txpool,personal,web3,XDPoS \
---rpcvhosts "*" \
---unlock "${wallet}" \
---password /work/.pwd \
---mine \
---gasprice "1" \
---targetgaslimit "420000000" \
---verbosity 3 \
---ws \
---wsaddr=0.0.0.0 \
---wsport 8555 \
---wsorigins "*" \
-2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
-
+    --ethstats ${netstats} \
+    --gcmode=archive \
+    --bootnodes ${bootnodes} \
+    --syncmode ${NODE_TYPE} \
+    --datadir /work/xdcchain \
+    --networkid 551 \
+    --XDCx.datadir /work/xdcchain/XDCx \
+    --port 30303 \
+    --rpc \
+    --rpccorsdomain "*" \
+    --rpcaddr 0.0.0.0 \
+    --rpcport 8545 \
+    --rpcapi db,eth,debug,miner,net,shh,txpool,personal,web3,XDPoS \
+    --rpcvhosts "*" \
+    --unlock "${wallet}" \
+    --password /work/.pwd \
+    --mine \
+    --gasprice "1" \
+    --targetgaslimit "420000000" \
+    --verbosity 3 \
+    --ws \
+    --wsaddr=0.0.0.0 \
+    --wsport 8555 \
+    --wsorigins "*" \
+    2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/mainnet/start-node.sh
+++ b/mainnet/start-node.sh
@@ -1,60 +1,55 @@
 #!/bin/bash
 
-if [ ! -d /work/xdcchain/XDC/chaindata ]
-then
-  wallet=$(XDC account new --password /work/.pwd --datadir /work/xdcchain | awk -F '[{}]' '{print $2}')
-  echo "Initalizing Genesis Block"
-  coinbaseaddr="$wallet"
-  coinbasefile=/work/xdcchain/coinbase.txt
-  touch $coinbasefile
-  if [ -f "$coinbasefile" ]
-  then
-      echo "$coinbaseaddr" > "$coinbasefile"
-  fi
-  XDC --datadir /work/xdcchain init /work/genesis.json
+if [ ! -d /work/xdcchain/XDC/chaindata ]; then
+    wallet=$(XDC account new --password /work/.pwd --datadir /work/xdcchain | awk -F '[{}]' '{print $2}')
+    echo "Initalizing Genesis Block"
+    coinbaseaddr="$wallet"
+    coinbasefile=/work/xdcchain/coinbase.txt
+    touch $coinbasefile
+    if [ -f "$coinbasefile" ]; then
+        echo "$coinbaseaddr" >"$coinbasefile"
+    fi
+    XDC init --datadir /work/xdcchain /work/genesis.json
 else
-  wallet=$(XDC account list --datadir /work/xdcchain| head -n 1 | awk -F '[{}]' '{print $2}')
+    wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
 fi
 
 input="/work/bootnodes.list"
 bootnodes=""
-while IFS= read -r line
-do
-    if [ -z "${bootnodes}" ]
-    then
+while IFS= read -r line; do
+    if [ -z "${bootnodes}" ]; then
         bootnodes=$line
     else
         bootnodes="${bootnodes},$line"
     fi
-done < "$input"
+done <"$input"
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${INSTANCE_NAME}:xinfin_xdpos_hybrid_network_stats@stats.xinfin.network:3000"
 
 echo "Starting nodes with $bootnodes ..."
 XDC \
---ethstats ${netstats} \
---bootnodes ${bootnodes} \
---syncmode ${NODE_TYPE} \
---datadir /work/xdcchain \
---XDCx.datadir /work/xdcchain/XDCx \
---networkid 50 \
---port 30303 \
---rpc \
---rpcapi db,eth,debug,net,shh,txpool,personal,web3,XDPoS \
---rpccorsdomain "*" \
---rpcaddr 0.0.0.0 \
---rpcport 8545 \
---rpcvhosts "*" \
---ws \
---wsapi db,eth,debug,net,shh,txpool,personal,web3,XDPoS \
---wsaddr="0.0.0.0" \
---wsorigins "*" \
---wsport 8546 \
---unlock "${wallet}" \
---password /work/.pwd \
---mine \
---gasprice "1" \
---targetgaslimit "420000000" \
---verbosity 3 \
-2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
-
+    --ethstats ${netstats} \
+    --bootnodes ${bootnodes} \
+    --syncmode ${NODE_TYPE} \
+    --datadir /work/xdcchain \
+    --XDCx.datadir /work/xdcchain/XDCx \
+    --networkid 50 \
+    --port 30303 \
+    --rpc \
+    --rpcapi db,eth,debug,net,shh,txpool,personal,web3,XDPoS \
+    --rpccorsdomain "*" \
+    --rpcaddr 0.0.0.0 \
+    --rpcport 8545 \
+    --rpcvhosts "*" \
+    --ws \
+    --wsapi db,eth,debug,net,shh,txpool,personal,web3,XDPoS \
+    --wsaddr="0.0.0.0" \
+    --wsorigins "*" \
+    --wsport 8546 \
+    --unlock "${wallet}" \
+    --password /work/.pwd \
+    --mine \
+    --gasprice "1" \
+    --targetgaslimit "420000000" \
+    --verbosity 3 \
+    2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -1,63 +1,58 @@
 #!/bin/bash
 
-if [ ! -d /work/xdcchain/XDC/chaindata ]
-then
-  wallet=$(XDC account new --password /work/.pwd --datadir /work/xdcchain | awk -F '[{}]' '{print $2}')
-  echo "Initializing Testnet Genesis Block"
-  echo "wallet: $wallet"
-  coinbaseaddr="$wallet"
-  coinbasefile=/work/xdcchain/coinbase.txt
-  touch $coinbasefile
-  if [ -f "$coinbasefile" ]
-  then
-      echo "$coinbaseaddr" > "$coinbasefile"
-  cat xdcchain/keystore/* >> "$coinbasefile"
-  fi
-  XDC --datadir /work/xdcchain init /work/genesis.json
+if [ ! -d /work/xdcchain/XDC/chaindata ]; then
+    wallet=$(XDC account new --password /work/.pwd --datadir /work/xdcchain | awk -F '[{}]' '{print $2}')
+    echo "Initializing Testnet Genesis Block"
+    echo "wallet: $wallet"
+    coinbaseaddr="$wallet"
+    coinbasefile=/work/xdcchain/coinbase.txt
+    touch $coinbasefile
+    if [ -f "$coinbasefile" ]; then
+        echo "$coinbaseaddr" >"$coinbasefile"
+        cat xdcchain/keystore/* >>"$coinbasefile"
+    fi
+    XDC init --datadir /work/xdcchain /work/genesis.json
 else
-  wallet=$(XDC account list --datadir /work/xdcchain| head -n 1 | awk -F '[{}]' '{print $2}')
-  echo "wallet: $wallet"
+    wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
+    echo "wallet: $wallet"
 fi
 
 input="/work/bootnodes.list"
 bootnodes=""
-while IFS= read -r line
-do
-    if [ -z "${bootnodes}" ]
-    then
+while IFS= read -r line; do
+    if [ -z "${bootnodes}" ]; then
         bootnodes=$line
     else
         bootnodes="${bootnodes},$line"
     fi
-done < "$input"
+done <"$input"
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${NODE_NAME}:xdc_xinfin_apothem_network_stats@stats.apothem.network:2000"
 
 echo "Starting nodes with $bootnodes ..."
 XDC \
---ethstats ${netstats} \
---gcmode=archive \
---bootnodes ${bootnodes} \
---syncmode ${NODE_TYPE} \
---datadir /work/xdcchain \
---XDCx.datadir /work/xdcchain/XDCx \
---networkid 51 \
---port 30304 \
---rpc \
---rpcapi eth,net,web3,XDPoS \
---rpccorsdomain "*" \
---rpcaddr 0.0.0.0 \
---rpcport 8555 \
---rpcvhosts "*" \
---unlock "${wallet}" \
---password /work/.pwd \
---mine \
---gasprice "1" \
---targetgaslimit "420000000" \
---verbosity 2 \
---ws \
---wsaddr=0.0.0.0 \
---wsport 8556 \
---wsorigins "*" \
-2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log
-
+    --ethstats ${netstats} \
+    --gcmode=archive \
+    --bootnodes ${bootnodes} \
+    --syncmode ${NODE_TYPE} \
+    --datadir /work/xdcchain \
+    --XDCx.datadir /work/xdcchain/XDCx \
+    --networkid 51 \
+    --port 30304 \
+    --rpc \
+    --rpcapi eth,net,web3,XDPoS \
+    --rpccorsdomain "*" \
+    --rpcaddr 0.0.0.0 \
+    --rpcport 8555 \
+    --rpcvhosts "*" \
+    --unlock "${wallet}" \
+    --password /work/.pwd \
+    --mine \
+    --gasprice "1" \
+    --targetgaslimit "420000000" \
+    --verbosity 2 \
+    --ws \
+    --wsaddr=0.0.0.0 \
+    --wsport 8556 \
+    --wsorigins "*" \
+    2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log


### PR DESCRIPTION
The flag `·--datadir` is the command option of the `init` command. It's not a global option. So it should be moved to the position after `init`.