### PR TITLE
fix bootnodes bug

### DIFF
--- a/devnet/start.sh
+++ b/devnet/start.sh
@@ -16,13 +16,6 @@ while IFS= read -r line; do
         bootnodes="${bootnodes},$line"
     fi
 done <"$input"
-#check last line since it's not included in "read" command https://stackoverflow.com/questions/12916352/shell-script-read-missing-last-line
-if [ -z "${bootnodes}" ]
-then
-    bootnodes=$line
-else
-    bootnodes="${bootnodes},$line"
-fi
 
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${wallet}_${INSTANCE_IP}:xinfin_xdpos_hybrid_network_stats@devnetstats.hashlabs.apothem.network:1999"

--- a/mainnet/start-node.sh
+++ b/mainnet/start-node.sh
@@ -23,13 +23,6 @@ while IFS= read -r line; do
         bootnodes="${bootnodes},$line"
     fi
 done <"$input"
-#check last line since it's not included in "read" command https://stackoverflow.com/questions/12916352/shell-script-read-missing-last-line
-if [ -z "${bootnodes}" ]
-then
-    bootnodes=$line
-else
-    bootnodes="${bootnodes},$line"
-fi
 
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${INSTANCE_NAME}:xinfin_xdpos_hybrid_network_stats@stats.xinfin.network:3000"

--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -26,13 +26,6 @@ while IFS= read -r line; do
         bootnodes="${bootnodes},$line"
     fi
 done <"$input"
-#check last line since it's not included in "read" command https://stackoverflow.com/questions/12916352/shell-script-read-missing-last-line
-if [ -z "${bootnodes}" ]
-then
-    bootnodes=$line
-else
-    bootnodes="${bootnodes},$line"
-fi
 
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
 netstats="${NODE_NAME}:xdc_xinfin_apothem_network_stats@stats.apothem.network:2000"


### PR DESCRIPTION
The following code add a comma to the end of variable `bootnodes`

```shell
if [ -z "${bootnodes}" ]
then
    bootnodes=$line
else
    bootnodes="${bootnodes},$line"
fi
```

It makes bootnodes become invalid and XDC report the error when start docker:

```text
ERROR[03-01|12:18:47] Bootstrap URL invalid                    enode= err="invalid URL scheme, want \"enode\""
```

![image](https://github.com/user-attachments/assets/cbcb8de0-53f4-4fad-8804-2fa30189821b)
