### PR TITLE
update golang version to 1.23

### DIFF
--- a/devnet/Dockerfile
+++ b/devnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.23
 
 WORKDIR /work
 

--- a/mainnet/Dockerfile
+++ b/mainnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.23
 
 WORKDIR /work
 


### PR DESCRIPTION
The XDPoSChain repository has upgraded to Go version 1.23 (see [#844](https://github.com/XinFinOrg/XDPoSChain/pull/844)). To ensure proper synchronization between nodes and avoid potential issues, XinFinNode should also use Go 1.23.