### PR TITLE
bump testnet to v2.6.7-testnet

### DIFF
--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xinfinnetwork:
-    image: xinfinorg/xdposchain:v2.6.6-testnet
+    image: xinfinorg/xdposchain:v2.6.7-testnet
     volumes:
       - "./xdcchain-testnet:/work/xdcchain"
       - "./start-apothem.sh:/work/start.sh"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testnet deployment image to v2.6.7, incorporating the latest infrastructure updates and service improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->