### PR TITLE
fix: sync container names in shell scripts with docker-compose.yml

### DIFF
--- a/mainnet/peer.sh
+++ b/mainnet/peer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-container_name="mainnet_xinfinnetwork_1"
+container_name="xdcnetwork-mainnet-node"
 filename="enode.txt"
 
 while IFS= read -r line || [[ -n "$line" ]]; do

--- a/testnet/peer.sh
+++ b/testnet/peer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-container_name="testnet_xinfinnetwork_1"
+container_name="xdcnetwork-testnet-node"
 filename="bootnodes.list"
 
 while IFS= read -r line || [[ -n "$line" ]]; do

--- a/testnet/update_block.sh
+++ b/testnet/update_block.sh
@@ -1,1 +1,1 @@
-sudo docker exec -it testnet-xinfinnetwork-1 XDC attach /work/XinFin-Node/testnet/xdcchain-1/XDC.ipc --exec "debug.setHead('0x4291040')"
+sudo docker exec -it xdcnetwork-testnet-node XDC attach /work/xdcchain/XDC.ipc --exec "debug.setHead('0x4291040')"


### PR DESCRIPTION
- Update mainnet/peer.sh: mainnet_xinfinnetwork_1 -> xdcnetwork-mainnet-node
- Update testnet/peer.sh: testnet_xinfinnetwork_1 -> xdcnetwork-testnet-node
- Update testnet/update_block.sh: testnet-xinfinnetwork-1 -> xdcnetwork-testnet-node
- Fix IPC path in update_block.sh to match docker volume mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker container references across mainnet and testnet deployment scripts to align with standardized naming conventions
  * Standardized network interaction paths in testnet operations for improved compatibility
  * Changes support infrastructure consolidation without impacting core functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->