### PR TITLE
change targetgaslimit from 50M to 80M for devnet

### DIFF
--- a/devnet/start.sh
+++ b/devnet/start.sh
@@ -65,7 +65,7 @@ args=(
     --password /work/.pwd
     --mine
     --gasprice "1"
-    --targetgaslimit "50000000"
+    --targetgaslimit "80000000"
     --verbosity "${log_level}"
     --store-reward
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum gas limit for transactions in the development environment from 50,000,000 to 80,000,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->