### PR TITLE
don't copy constants for devnet

### DIFF
--- a/devnet/Dockerfile
+++ b/devnet/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install -y git build-essential
 
 RUN git clone https://github.com/XinFinOrg/XDPoSChain.git xdcchain && cd xdcchain && git checkout dev-upgrade
 
-RUN mv /work/xdcchain/common/constants/constants.go.devnet /work/xdcchain/common/constants.go
 RUN cd /work/xdcchain/ && make
 RUN cp /work/xdcchain/build/bin/XDC /usr/bin && chmod +x /usr/bin/XDC
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated devnet build process by removing a constants replacement step during image build. The build will now use standard constants instead of devnet-specific ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->