### PR TITLE
Rename testnet peer.sh container name to xdcnetwork-testnet-node

### DIFF
--- a/testnet/peer.sh
+++ b/testnet/peer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-container_name="testnet_xinfinnetwork_1"
+container_name="xdcnetwork-testnet-node"
 filename="bootnodes.list"
 
 while IFS= read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
TLDR:
Updates testnet/peer.sh to use the current Docker container name:

- old: testnet_xinfinnetwork_1
- new: xdcnetwork-testnet-node

This fixes the script so docker exec targets the correct running testnet container.

Detailed explanation:
While installing the node using the bootstrap mode, the docker container name uses "xdcnetwork-testnet-node".  If the node does not immediately find peers. The recommendation was to run bash peer.sh but running bash peer.sh gives an error: 

root@vmi2927821:/xdcnode/XinFin-Node/testnet# bash peer.sh

enode://9a20f2554cf495945ed24be380b3f3b95ad6a732c3954500a1270ffab0e64b1631ec12f6bdd618026bcb1bd27ba36736defe264cf664ab26be0bb1b13aff1e12@38.242.205.0:30312 Error response from daemon: No such container: testnet_xinfinnetwork_1

enode://ee1e11e3f56b015b2b391eb9c45292159713583b4adfe29d24675238f73d33e6ec0a62397847823e2bca622c91892075c517fc383c9355d43a89bb7532e834a0@157.173.120.219:30312 Error response from daemon: No such container: testnet_xinfinnetwork_1

enode://18799318d5ca266ca7a030d05a1a3a3b20d16db41eb8950ab448cb2a8f41519a1b05b36cac508ecfc590b7701719e3012511dbfcab9d2815a8d04ba6ac5c59ab@167.224.64.218:30312 Error response from daemon: No such container: testnet_xinfinnetwork_1

Due to this, the command fails. Changing the name to the one suggested, will allow the script to run, and allowing the node to find peers instantly.