### PR TITLE
Update docker container name in minor-update.sh

### DIFF
--- a/setup/minor-update.sh
+++ b/setup/minor-update.sh
@@ -1,1 +1,1 @@
-sudo docker exec -it xinfin-node_xinfinnetwork_1  XDC --exec 'eth.coinbase' --exec 'miner.setEtherbase(eth.accounts[0])' attach /work/xdcchain/XDC.ipc
+sudo docker exec -it xdcnetwork-testnet-node  XDC --exec 'eth.coinbase' --exec 'miner.setEtherbase(eth.accounts[0])' attach /work/xdcchain/XDC.ipc


### PR DESCRIPTION
Changing to match container name: 
xdcnetwork-testnet-node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup configuration to use the current testnet container target for network initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->