### PR TITLE
Update Docker container name in xdc-attach2.sh

### DIFF
--- a/devnet/xdc-attach2.sh
+++ b/devnet/xdc-attach2.sh
@@ -1,1 +1,1 @@
-sudo docker exec -it devnet_xinfinnetwork2_1 XDC attach /work/xdcchain/XDC.ipc
+sudo docker exec -it xdcnetwork-devnet-node-2 XDC attach /work/xdcchain/XDC.ipc


### PR DESCRIPTION
Changing name to match container name in script for consistency across networks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container reference in the development network attach script for compatibility with the current infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->