### PR TITLE
Update Mainnet Docker image version to v2.7.0

### DIFF
--- a/mainnet/docker-compose-hash-rpc.yml
+++ b/mainnet/docker-compose-hash-rpc.yml
@@ -1,9 +1,0 @@
-services:
-  xinfinnetwork:
-    image: ${RPC_IMAGE}
-    volumes:
-      - "./xdcchain-1:/work/xdcchain"
-    restart: "always"
-    env_file: "./.env"
-    ports:
-      - "30303:30303"

--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   xinfinnetwork:
     container_name: xdcnetwork-mainnet-node
-    image: xinfinorg/xdposchain:v2.6.8
+    image: xinfinorg/xdposchain:v2.7.0
     volumes:
       - "./xdcchain:/work/xdcchain"
       - "./genesis.json:/work/genesis.json"

--- a/mainnet/docker-up-hash.sh
+++ b/mainnet/docker-up-hash.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker compose -f docker-compose-hash-rpc.yml up -d --build --force-recreate

--- a/mainnet/upgrade.sh
+++ b/mainnet/upgrade.sh
@@ -12,7 +12,6 @@ mv .env.bak .env
 mv .nodekey.bak .nodekey
 
 echo "Upgrading Docker Images"
-sudo docker pull xinfinorg/xdposchain:v2.6.8
 docker compose -f docker-compose.yml down
 git pull
 docker compose -f docker-compose.yml up -d


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the network node container image to v2.7.0.
  * Simplified the upgrade flow (no explicit pre-pull of the previous image).

* **Chores / Breaking change**
  * Removed the bundled RPC node and its automated startup scripts — the RPC service will no longer be started by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->