### PR TITLE
feat: always pull latest docker image on compose up

### DIFF
--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "./bootnodes.list:/work/bootnodes.list"
       - "./.pwd:/work/.pwd"
       - "/etc/localtime:/etc/localtime:ro"
+    pull_policy: always
     restart: "always"
     env_file:
       - .env

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "./bootnodes.list:/work/bootnodes.list"
       - "./.pwd:/work/.pwd"
       - "/etc/localtime:/etc/localtime:ro"
+    pull_policy: always
     restart: "always"
     env_file:
       - .env


### PR DESCRIPTION
Add pull_policy: always to both mainnet and testnet docker-compose.yml so that docker compose up always fetches the latest image from the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for mainnet and testnet to ensure container images are always pulled fresh during deployment. This guarantees the latest version of services is used when stacks are created or restarted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XinFinOrg/XinFin-Node/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->