### PR TITLE
feat: add fast sync pivot support to mainnet and testnet start scripts

### DIFF
--- a/mainnet/README.md
+++ b/mainnet/README.md
@@ -28,10 +28,28 @@ cp env.example .env
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SYNC_MODE` | No | `full` | Blockchain sync mode: `full` |
+| `SYNC_MODE` | No | `full` | Blockchain sync mode: `full` (replay every block) or `fast` (download state at a pivot and replay from there). `fast` requires the `FASTSYNC_PIVOT_*` variables below. |
 | `GC_MODE` | No | `archive` | Garbage-collection mode: `archive` (keeps all state) or `full` (prunes old state) |
 
 > Use `GC_MODE=archive` if you need to query historical state (e.g. for an explorer or analytics node). `GC_MODE=full` saves significant disk space for a standard validator or relay node.
+
+### Fast Sync Pivot
+
+Required only when `SYNC_MODE=fast`. All three variables must be set together — `start-node.sh` will refuse to start if only some are provided.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FASTSYNC_PIVOT_NUMBER` | If `SYNC_MODE=fast` | — | Block number to fast-sync to (the pivot). Passed as `--fastsyncpivotnumber`. |
+| `FASTSYNC_PIVOT_HASH` | If `SYNC_MODE=fast` | — | Hash of the pivot block. Passed as `--fastsyncpivothash`. |
+| `FASTSYNC_PIVOT_ROOT` | If `SYNC_MODE=fast` | — | State root of the pivot block. Passed as `--fastsyncpivotroot`. |
+
+> Run `bash get_pivot_for_fast_sync.sh` to extract a fresh pivot (block number, hash, and state root) from a public XinFin RPC node. The script prints the values in `.env` format, so you can append the output directly:
+>
+> ```bash
+> bash get_pivot_for_fast_sync.sh >> .env
+> ```
+>
+> The script defaults to `https://erpc.xinfin.network` and can be pointed at another endpoint with `RPC_URL=... bash get_pivot_for_fast_sync.sh`. It requires `jq` and `curl`.
 
 ### HTTP-RPC (JSON-RPC)
 
@@ -74,8 +92,11 @@ These flags are passed to the `XDC` binary by `start-node.sh`. Most are derived 
 |---|---|---|
 | `--ethstats` | `INSTANCE_NAME` + stats server | Reports node status to the XinFin stats dashboard |
 | `--bootnodes` | `bootnodes.list` | Comma-separated enode URLs used for initial peer discovery |
-| `--syncmode` | `SYNC_MODE` | Blockchain sync strategy (`full`) |
+| `--syncmode` | `SYNC_MODE` | Blockchain sync strategy (`full` or `fast`) |
 | `--gcmode` | `GC_MODE` | State trie garbage-collection mode (`archive` or `full`) |
+| `--fastsyncpivotnumber` | `FASTSYNC_PIVOT_NUMBER` | Pivot block number for `SYNC_MODE=fast` |
+| `--fastsyncpivothash` | `FASTSYNC_PIVOT_HASH` | Pivot block hash for `SYNC_MODE=fast` |
+| `--fastsyncpivotroot` | `FASTSYNC_PIVOT_ROOT` | Pivot block state root for `SYNC_MODE=fast` |
 | `--datadir` | `/work/xdcchain` | Directory for chain data and keystore |
 | `--XDCx.datadir` | `/work/xdcchain/XDCx` | Directory for XDCx (DEX) data |
 | `--networkid` | `50` | XinFin mainnet chain ID |

--- a/mainnet/get_pivot_for_fast_sync.sh
+++ b/mainnet/get_pivot_for_fast_sync.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# RPC endpoint (can be overridden with env var)
+RPC_URL="${RPC_URL:-https://erpc.xinfin.network}"
+
+# Epoch and switchEpoch for mainnet
+epoch=900
+switchEpoch=89300
+
+# Step 1: Get current epoch number from masternodes
+epoch_response=$(curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "XDPoS_getMasternodesByNumber",
+    "params": ["latest"],
+    "id": 1
+  }')
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed. Please install jq."
+    exit 1
+fi
+
+# Check for RPC error
+error=$(echo "$epoch_response" | jq -r '.error // empty')
+if [ -n "$error" ]; then
+    echo "Error from XDPoS_getMasternodesByNumber: $error"
+    exit 1
+fi
+
+# 1. Parse current_round from $epoch_response
+current_round=$(echo "$epoch_response" | jq -r '.result.Round')
+if [ -z "$current_round" ] || [ "$current_round" = "null" ]; then
+    echo "Error: Could not parse round from response"
+    echo "Response: $epoch_response"
+    exit 1
+fi
+
+# 2. Calculate current_epoch = floor(current_round/epoch) + switchEpoch
+# Using jq 'floor' for integer division
+current_epoch=$(jq -n \
+    --arg round "$current_round" \
+    --arg epoch "$epoch" \
+    --arg switch "$switchEpoch" \
+    '(($round | tonumber) / ($epoch | tonumber) | floor) + ($switch | tonumber)')
+
+# Step 2: Get block info by epoch number
+block_info_response=$(curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"XDPoS_getBlockInfoByEpochNum\",
+    \"params\": [$current_epoch],
+    \"id\": 1
+  }")
+
+# Check for RPC error
+error=$(echo "$block_info_response" | jq -r '.error // empty')
+if [ -n "$error" ]; then
+    echo "Error from XDPoS_getBlockInfoByEpochNum: $error"
+    exit 1
+fi
+
+# Step 3: Parse block number, hash, and state root
+block_number=$(echo "$block_info_response" | jq -r '.result.firstBlock')
+block_hash=$(echo "$block_info_response" | jq -r '.result.hash')
+
+# State root needs to be fetched separately using eth_getBlockByHash
+block_details=$(curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"eth_getBlockByHash\",
+    \"params\": [\"$block_hash\", false],
+    \"id\": 1
+  }")
+
+state_root=$(echo "$block_details" | jq -r '.result.stateRoot')
+
+if [ -z "$block_number" ] || [ "$block_number" = "null" ]; then
+    echo "Error: Could not parse block number from response"
+    echo "Response: $block_info_response"
+    exit 1
+fi
+
+if [ -z "$block_hash" ] || [ "$block_hash" = "null" ]; then
+    echo "Error: Could not parse block hash from response"
+    echo "Response: $block_info_response"
+    exit 1
+fi
+
+if [ -z "$state_root" ] || [ "$state_root" = "null" ]; then
+    echo "Error: Could not parse state root from response"
+    echo "Response: $block_details"
+    exit 1
+fi
+
+# Output in the requested format
+cat << EOF
+SYNC_MODE=fast
+FASTSYNC_PIVOT_NUMBER=$block_number
+FASTSYNC_PIVOT_HASH=$block_hash
+FASTSYNC_PIVOT_ROOT=$state_root
+EOF

--- a/mainnet/start-node.sh
+++ b/mainnet/start-node.sh
@@ -38,6 +38,12 @@ DATE="$(date +%Y%m%d-%H%M%S)"
 LOG_FILE="/work/xdcchain/xdc-${DATE}.log"
 
 sync_mode=full
+if test -z "$SYNC_MODE"; then
+    echo "SYNC_MODE not set, default to $sync_mode" # full or fast
+else
+    echo "SYNC_MODE found, set to $SYNC_MODE"
+    sync_mode=$SYNC_MODE
+fi
 
 # Set store_reward from STORE_REWARD env or default to 'false'
 store_reward=false
@@ -55,6 +61,23 @@ if test -z "$GC_MODE"; then
 else
     echo "GC_MODE found, set to $GC_MODE"
     gc_mode=$GC_MODE
+fi
+
+# Set fast sync pivot args - all three must be provided together
+fastsync_args=()
+if test -n "$FASTSYNC_PIVOT_NUMBER" || test -n "$FASTSYNC_PIVOT_HASH" || test -n "$FASTSYNC_PIVOT_ROOT"; then
+    if test -z "$FASTSYNC_PIVOT_NUMBER" || test -z "$FASTSYNC_PIVOT_HASH" || test -z "$FASTSYNC_PIVOT_ROOT"; then
+        echo "Error: FASTSYNC_PIVOT_NUMBER, FASTSYNC_PIVOT_HASH, and FASTSYNC_PIVOT_ROOT must all be set together."
+        exit 1
+    fi
+    echo "FASTSYNC_PIVOT_NUMBER found, set to $FASTSYNC_PIVOT_NUMBER"
+    echo "FASTSYNC_PIVOT_HASH found, set to $FASTSYNC_PIVOT_HASH"
+    echo "FASTSYNC_PIVOT_ROOT found, set to $FASTSYNC_PIVOT_ROOT"
+    fastsync_args=(
+        --fastsyncpivotnumber "${FASTSYNC_PIVOT_NUMBER}"
+        --fastsyncpivothash "${FASTSYNC_PIVOT_HASH}"
+        --fastsyncpivotroot "${FASTSYNC_PIVOT_ROOT}"
+    )
 fi
 
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
@@ -83,6 +106,9 @@ args=(
 if [[ "${store_reward}" == "true" ]]; then
     args+=(--store-reward)
 fi
+
+# Append fast sync pivot args if provided
+args+=("${fastsync_args[@]}")
 
 # RPC and WebSocket configuration - exact match required for security
 if [[ "${ENABLE_RPC}" == "true" ]]; then

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -28,10 +28,28 @@ cp env.example .env
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SYNC_MODE` | No | `full` | Blockchain sync mode: `full` |
+| `SYNC_MODE` | No | `full` | Blockchain sync mode: `full` (replay every block) or `fast` (download state at a pivot and replay from there). `fast` requires the `FASTSYNC_PIVOT_*` variables below. |
 | `GC_MODE` | No | `archive` | Garbage-collection mode: `archive` (keeps all state) or `full` (prunes old state) |
 
 > Use `GC_MODE=archive` if you need to query historical state. `GC_MODE=full` saves significant disk space for a standard validator or relay node.
+
+### Fast Sync Pivot
+
+Required only when `SYNC_MODE=fast`. All three variables must be set together — `start-apothem.sh` will refuse to start if only some are provided.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FASTSYNC_PIVOT_NUMBER` | If `SYNC_MODE=fast` | — | Block number to fast-sync to (the pivot). Passed as `--fastsyncpivotnumber`. |
+| `FASTSYNC_PIVOT_HASH` | If `SYNC_MODE=fast` | — | Hash of the pivot block. Passed as `--fastsyncpivothash`. |
+| `FASTSYNC_PIVOT_ROOT` | If `SYNC_MODE=fast` | — | State root of the pivot block. Passed as `--fastsyncpivotroot`. |
+
+> Run `bash get_pivot_for_fast_sync.sh` to extract a fresh pivot (block number, hash, and state root) from a public Apothem RPC node. The script prints the values in `.env` format, so you can append the output directly:
+>
+> ```bash
+> bash get_pivot_for_fast_sync.sh >> .env
+> ```
+>
+> The script defaults to `https://earpc.apothem.network` and can be pointed at another endpoint with `RPC_URL=... bash get_pivot_for_fast_sync.sh`. It requires `jq` and `curl`.
 
 ### HTTP-RPC (JSON-RPC)
 
@@ -74,8 +92,11 @@ These flags are passed to the `XDC` binary by `start-apothem.sh`. Most are deriv
 |---|---|---|
 | `--ethstats` | `NODE_NAME` + stats server | Reports node status to the Apothem stats dashboard |
 | `--bootnodes` | `bootnodes.list` | Comma-separated enode URLs used for initial peer discovery |
-| `--syncmode` | `SYNC_MODE` | Blockchain sync strategy (`full`) |
+| `--syncmode` | `SYNC_MODE` | Blockchain sync strategy (`full` or `fast`) |
 | `--gcmode` | `GC_MODE` | State trie garbage-collection mode (`archive` or `full`) |
+| `--fastsyncpivotnumber` | `FASTSYNC_PIVOT_NUMBER` | Pivot block number for `SYNC_MODE=fast` |
+| `--fastsyncpivothash` | `FASTSYNC_PIVOT_HASH` | Pivot block hash for `SYNC_MODE=fast` |
+| `--fastsyncpivotroot` | `FASTSYNC_PIVOT_ROOT` | Pivot block state root for `SYNC_MODE=fast` |
 | `--datadir` | `/work/xdcchain` | Directory for chain data and keystore |
 | `--XDCx.datadir` | `/work/xdcchain/XDCx` | Directory for XDCx (DEX) data |
 | `--networkid` | `51` | XinFin Apothem testnet chain ID |

--- a/testnet/get_pivot_for_fast_sync.sh
+++ b/testnet/get_pivot_for_fast_sync.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# RPC endpoint (can be overridden with env var)
+RPC_URL="${RPC_URL:-https://earpc.apothem.network}"
+
+# Epoch and switchEpoch for testnet
+epoch=900
+switchEpoch=63143
+
+# Step 1: Get current epoch number from masternodes
+epoch_response=$(curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "XDPoS_getMasternodesByNumber",
+    "params": ["latest"],
+    "id": 1
+  }')
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed. Please install jq."
+    exit 1
+fi
+
+# Check for RPC error
+error=$(echo "$epoch_response" | jq -r '.error // empty')
+if [ -n "$error" ]; then
+    echo "Error from XDPoS_getMasternodesByNumber: $error"
+    exit 1
+fi
+
+# 1. Parse current_round from $epoch_response
+current_round=$(echo "$epoch_response" | jq -r '.result.Round')
+if [ -z "$current_round" ] || [ "$current_round" = "null" ]; then
+    echo "Error: Could not parse round from response"
+    echo "Response: $epoch_response"
+    exit 1
+fi
+
+# 2. Calculate current_epoch = floor(current_round/epoch) + switchEpoch
+# Using jq 'floor' for integer division
+current_epoch=$(jq -n \
+    --arg round "$current_round" \
+    --arg epoch "$epoch" \
+    --arg switch "$switchEpoch" \
+    '(($round | tonumber) / ($epoch | tonumber) | floor) + ($switch | tonumber)')
+
+# Step 2: Get block info by epoch number
+block_info_response=$(curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"XDPoS_getBlockInfoByEpochNum\",
+    \"params\": [$current_epoch],
+    \"id\": 1
+  }")
+
+# Check for RPC error
+error=$(echo "$block_info_response" | jq -r '.error // empty')
+if [ -n "$error" ]; then
+    echo "Error from XDPoS_getBlockInfoByEpochNum: $error"
+    exit 1
+fi
+
+# Step 3: Parse block number, hash, and state root
+block_number=$(echo "$block_info_response" | jq -r '.result.firstBlock')
+block_hash=$(echo "$block_info_response" | jq -r '.result.hash')
+
+# State root needs to be fetched separately using eth_getBlockByHash
+block_details=$(curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"eth_getBlockByHash\",
+    \"params\": [\"$block_hash\", false],
+    \"id\": 1
+  }")
+
+state_root=$(echo "$block_details" | jq -r '.result.stateRoot')
+
+if [ -z "$block_number" ] || [ "$block_number" = "null" ]; then
+    echo "Error: Could not parse block number from response"
+    echo "Response: $block_info_response"
+    exit 1
+fi
+
+if [ -z "$block_hash" ] || [ "$block_hash" = "null" ]; then
+    echo "Error: Could not parse block hash from response"
+    echo "Response: $block_info_response"
+    exit 1
+fi
+
+if [ -z "$state_root" ] || [ "$state_root" = "null" ]; then
+    echo "Error: Could not parse state root from response"
+    echo "Response: $block_details"
+    exit 1
+fi
+
+# Output in the requested format
+cat << EOF
+SYNC_MODE=fast
+FASTSYNC_PIVOT_NUMBER=$block_number
+FASTSYNC_PIVOT_HASH=$block_hash
+FASTSYNC_PIVOT_ROOT=$state_root
+EOF

--- a/testnet/start-apothem.sh
+++ b/testnet/start-apothem.sh
@@ -41,6 +41,12 @@ DATE="$(date +%Y%m%d-%H%M%S)"
 LOG_FILE="/work/xdcchain/xdc-${DATE}.log"
 
 sync_mode=full
+if test -z "$SYNC_MODE"; then
+    echo "SYNC_MODE not set, default to $sync_mode" # full or fast
+else
+    echo "SYNC_MODE found, set to $SYNC_MODE"
+    sync_mode=$SYNC_MODE
+fi
 
 # Set store_reward from STORE_REWARD env or default to 'false'
 store_reward=false
@@ -58,6 +64,23 @@ if test -z "$GC_MODE"; then
 else
     echo "GC_MODE found, set to $GC_MODE"
     gc_mode=$GC_MODE
+fi
+
+# Set fast sync pivot args - all three must be provided together
+fastsync_args=()
+if test -n "$FASTSYNC_PIVOT_NUMBER" || test -n "$FASTSYNC_PIVOT_HASH" || test -n "$FASTSYNC_PIVOT_ROOT"; then
+    if test -z "$FASTSYNC_PIVOT_NUMBER" || test -z "$FASTSYNC_PIVOT_HASH" || test -z "$FASTSYNC_PIVOT_ROOT"; then
+        echo "Error: FASTSYNC_PIVOT_NUMBER, FASTSYNC_PIVOT_HASH, and FASTSYNC_PIVOT_ROOT must all be set together."
+        exit 1
+    fi
+    echo "FASTSYNC_PIVOT_NUMBER found, set to $FASTSYNC_PIVOT_NUMBER"
+    echo "FASTSYNC_PIVOT_HASH found, set to $FASTSYNC_PIVOT_HASH"
+    echo "FASTSYNC_PIVOT_ROOT found, set to $FASTSYNC_PIVOT_ROOT"
+    fastsync_args=(
+        --fastsyncpivotnumber "${FASTSYNC_PIVOT_NUMBER}"
+        --fastsyncpivothash "${FASTSYNC_PIVOT_HASH}"
+        --fastsyncpivotroot "${FASTSYNC_PIVOT_ROOT}"
+    )
 fi
 
 INSTANCE_IP=$(curl https://checkip.amazonaws.com)
@@ -84,6 +107,9 @@ args=(
 if [[ "${store_reward}" == "true" ]]; then
     args+=(--store-reward)
 fi
+
+# Append fast sync pivot args if provided
+args+=("${fastsync_args[@]}")
 
 # RPC and WebSocket configuration - exact match required for security
 if [[ "${ENABLE_RPC}" == "true" ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node startup scripts now accept SYNC_MODE (default: full) and support a validated fast-sync pivot trio that is applied to node startup when provided.
  * Added helper scripts that query RPC endpoints to generate the fast-sync pivot env variables.

* **Documentation**
  * Updated mainnet and testnet docs to describe SYNC_MODE, the fast-sync pivot variables, and the corresponding node flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->